### PR TITLE
refactor(ast): introduce typed AST node structs for if/while/for statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@
 .idea
 /build
 /cmake-build-debug
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,18 @@
-cmake_minimum_required(VERSION 3.31)
+cmake_minimum_required(VERSION 3.10)
 project(CypLang C)
 
 set(CMAKE_C_STANDARD 11)
 
-add_executable(CypLang src/main.c
+add_executable(CypLang
+        src/main.c
         src/frontend/token/token.h
         src/frontend/ast/ast.h
-        src/frontend/lexer/lexer.h
-        src/frontend/parser/parser.h
-        src/frontend/lexer/lexer.c
-        src/frontend/parser/parser.c
         src/frontend/ast/ast.c
+        src/frontend/lexer/lexer.h
+        src/frontend/lexer/lexer.c
+        src/frontend/parser/parser.h
+        src/frontend/parser/parser.c
+        src/middle/ir_generator.h
         src/middle/ir_generator.c
-        src/backend/llvm_emitter.c
-        src/middle/ir_generator.h)
+        src/backend/llvm_emitter.c)
 

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ FILE ?= input.cyp
 # The final executable
 TARGET = $(BIN_DIR)/cyplang
 
-# Source files
-SRCS = $(wildcard $(SRC_DIR)/*.c)
+# Source files (recursive: src/, src/frontend/**, src/middle/, src/backend/)
+SRCS = $(shell find $(SRC_DIR) -name '*.c')
 OBJS = $(patsubst $(SRC_DIR)/%.c,$(OBJ_DIR)/%.o,$(SRCS))
 
 # Create directories if they don't exist
@@ -34,8 +34,9 @@ $(TARGET): $(OBJS)
 	$(CC) $^ -o $@ $(LDFLAGS)
 	@echo "Build complete!"
 
-# Compiling source files
+# Compiling source files (mkdir handles nested obj subdirs)
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
+	@mkdir -p $(dir $@)
 	@echo "Compiling $<..."
 	$(CC) $(CFLAGS) -c $< -o $@
 

--- a/src/frontend/ast/ast.c
+++ b/src/frontend/ast/ast.c
@@ -64,17 +64,19 @@ void print_ast(AstNode* node, int depth) {
             printf("%s  Valeur:\n", indent);
             print_ast(((AstAssignment*)node)->value, depth + 2);
             break;
-        case AST_IF_STATEMENT:
+        case AST_IF_STATEMENT: {
+            AstIfStatement* if_stmt = (AstIfStatement*)node;
             printf("%sCondition Si\n", indent);
             printf("%s  Condition:\n", indent);
-            print_ast(((AstBlock*)node)->statements[0], depth + 2);
+            print_ast(if_stmt->condition, depth + 2);
             printf("%s  Alors:\n", indent);
-            print_ast(((AstBlock*)node)->statements[1], depth + 2);
-            if (((AstBlock*)node)->statements[2]) {
+            print_ast(if_stmt->then_branch, depth + 2);
+            if (if_stmt->else_branch) {
                 printf("%s  Sinon:\n", indent);
-                print_ast(((AstBlock*)node)->statements[2], depth + 2);
+                print_ast(if_stmt->else_branch, depth + 2);
             }
             break;
+        }
         case AST_WHILE_STATEMENT:
             printf("%sBoucle Tant Que\n", indent);
             printf("%s  Condition:\n", indent);
@@ -96,9 +98,15 @@ void print_ast(AstNode* node, int depth) {
             printf("%sRetour\n", indent);
             print_ast(((AstReturnStatement*)node)->value, depth + 1);
             break;
-        case AST_FUNCTION_CALL:
-            printf("%sAppel de fonction: %s\n", indent, ((AstFunctionCall*)node)->name);
+        case AST_FUNCTION_CALL: {
+            AstFunctionCall* call = (AstFunctionCall*)node;
+            printf("%sAppel de fonction: %s (%d arg)\n", indent, call->name, call->argument_count);
+            for (int i = 0; i < call->argument_count; i++) {
+                printf("%s  Argument %d:\n", indent, i + 1);
+                print_ast(call->arguments[i], depth + 2);
+            }
             break;
+        }
         case AST_VARIABLE:
             printf("%sVariable: %s\n", indent, ((AstVariable*)node)->name);
             break;
@@ -231,20 +239,15 @@ AstNode* create_assignment_node(AstNode* target, AstNode* value) {
 }
 
 AstNode* create_if_stmt_node(AstNode* condition, AstNode* then_branch, AstNode* else_branch) {
-    // We're using a dummy struct for if statements until we create a proper one
-    // This is a placeholder implementation
-    AstBlock* if_stmt = (AstBlock*)malloc(sizeof(AstBlock));
+    AstIfStatement* if_stmt = (AstIfStatement*)malloc(sizeof(AstIfStatement));
     if (!if_stmt) {
         fprintf(stderr, "Erreur d'allocation mémoire\n");
         exit(EXIT_FAILURE);
     }
     if_stmt->base.type = AST_IF_STATEMENT;
-    // For now, just add the condition and branches to the statements array
-    if_stmt->statements = malloc(3 * sizeof(AstNode*));
-    if_stmt->statements[0] = condition;
-    if_stmt->statements[1] = then_branch;
-    if_stmt->statements[2] = else_branch;
-    if_stmt->statement_count = 3;
+    if_stmt->condition = condition;
+    if_stmt->then_branch = then_branch;
+    if_stmt->else_branch = else_branch;
     return (AstNode*)if_stmt;
 }
 
@@ -287,7 +290,6 @@ AstNode* create_return_stmt_node(AstNode* value) {
 }
 
 AstNode* create_function_call_node(char* name, AstNode** arguments, int argument_count) {
-    // This is a placeholder implementation
     AstFunctionCall* call = (AstFunctionCall*)malloc(sizeof(AstFunctionCall));
     if (!call) {
         fprintf(stderr, "Erreur d'allocation mémoire\n");
@@ -295,7 +297,8 @@ AstNode* create_function_call_node(char* name, AstNode** arguments, int argument
     }
     call->base.type = AST_FUNCTION_CALL;
     call->name = strdup(name);
-    // Note: We're not storing the arguments here, this would need to be extended
+    call->arguments = arguments;
+    call->argument_count = argument_count;
     return (AstNode*)call;
 }
 
@@ -460,13 +463,10 @@ void free_ast_node(AstNode* node) {
             break;
         }
         case AST_IF_STATEMENT: {
-            AstBlock* if_stmt = (AstBlock*)node;
-            for (int i = 0; i < if_stmt->statement_count; i++) {
-                if (if_stmt->statements[i]) {
-                    free_ast_node(if_stmt->statements[i]);
-                }
-            }
-            free(if_stmt->statements);
+            AstIfStatement* if_stmt = (AstIfStatement*)node;
+            free_ast_node(if_stmt->condition);
+            free_ast_node(if_stmt->then_branch);
+            if (if_stmt->else_branch) free_ast_node(if_stmt->else_branch);
             break;
         }
         case AST_WHILE_STATEMENT: {
@@ -492,6 +492,10 @@ void free_ast_node(AstNode* node) {
         }
         case AST_FUNCTION_CALL: {
             AstFunctionCall* call = (AstFunctionCall*)node;
+            for (int i = 0; i < call->argument_count; i++) {
+                free_ast_node(call->arguments[i]);
+            }
+            free(call->arguments);
             free(call->name);
             break;
         }

--- a/src/frontend/ast/ast.h
+++ b/src/frontend/ast/ast.h
@@ -94,6 +94,13 @@ typedef struct {
 typedef struct {
     AstNode base;
     struct AstNode* condition;
+    struct AstNode* then_branch;
+    struct AstNode* else_branch;
+} AstIfStatement;
+
+typedef struct {
+    AstNode base;
+    struct AstNode* condition;
     struct AstNode* body;
 } AstWhileStatement;
 
@@ -114,6 +121,8 @@ typedef struct {
 typedef struct {
     AstNode base;
     char* name;
+    struct AstNode** arguments;
+    int argument_count;
 } AstFunctionCall;
 
 typedef struct {

--- a/src/frontend/parser/parser.c
+++ b/src/frontend/parser/parser.c
@@ -467,7 +467,9 @@ AstNode* parse_return_statement(Parser* parser) {
 }
 
 AstNode* parse_block(Parser* parser) {
-    AstNode* statements = create_block_node();
+    AstBlock* block = (AstBlock*)create_block_node();
+    int capacity = 8;
+    block->statements = malloc(capacity * sizeof(AstNode*));
 
     while (parser->current_token->type != TOKEN_EOF &&
            parser->current_token->type != TOKEN_FINSI &&
@@ -476,13 +478,14 @@ AstNode* parse_block(Parser* parser) {
            parser->current_token->type != TOKEN_FINFONC) {
 
         AstNode* stmt = parse_statement(parser);
-        if (stmt) {
-            // Add statement to block - pour l'instant on retourne simplement le statement
-            // TODO: implémenter la logique pour ajouter au block
-        } else {
-            break;
+        if (!stmt) break;
+
+        if (block->statement_count >= capacity) {
+            capacity *= 2;
+            block->statements = realloc(block->statements, capacity * sizeof(AstNode*));
         }
+        block->statements[block->statement_count++] = stmt;
     }
 
-    return statements;
+    return (AstNode*)block;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -2,12 +2,16 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define MAX_FILE_SIZE 1024 * 1024 // 1MB
+#include "frontend/lexer/lexer.h"
+#include "frontend/parser/parser.h"
+#include "frontend/ast/ast.h"
+#include "middle/ir_generator.h"
 
-char* readFile(const char* filename);
-void processCypLang(const char* source);
+#define MAX_FILE_SIZE (1024 * 1024) // 1MB
 
-int main(int argc, char *argv[]) {
+static char* readFile(const char* filename);
+
+int main(int argc, char* argv[]) {
     const char* defaultFile = "input.cyp";
     const char* filename;
 
@@ -24,23 +28,71 @@ int main(int argc, char *argv[]) {
         return EXIT_FAILURE;
     }
 
-    printf("Processing CypLang file: %s\n", filename);
+    printf("=== Source (%s) ===\n%s\n", filename, source);
 
-    processCypLang(source);
+    // 1. Lexer
+    Lexer* lexer = init_lexer(source);
+    if (!lexer) {
+        fprintf(stderr, "Failed to initialize lexer\n");
+        free(source);
+        return EXIT_FAILURE;
+    }
 
+    // 2. Parser → AST
+    Parser* parser = init_parser(lexer);
+    if (!parser) {
+        fprintf(stderr, "Failed to initialize parser\n");
+        free_lexer(lexer);
+        free(source);
+        return EXIT_FAILURE;
+    }
+
+    AstNode* ast = parse(parser);
+    if (!ast) {
+        fprintf(stderr, "Parsing failed\n");
+        free_parser(parser);
+        free_lexer(lexer);
+        free(source);
+        return EXIT_FAILURE;
+    }
+
+    printf("\n=== AST ===\n");
+    print_ast(ast, 0);
+
+    // 3. IR generation
+    IRProgram* ir = generate_ir(ast);
+    if (!ir) {
+        fprintf(stderr, "IR generation failed\n");
+        free_ast_node(ast);
+        free_parser(parser);
+        free_lexer(lexer);
+        free(source);
+        return EXIT_FAILURE;
+    }
+
+    printf("\n");
+    ir_print_program(ir);
+
+    // TODO(phase1.5): ir_free_program double-frees because IR temp strings
+    // (t0, t1...) are shared by pointer across instructions instead of
+    // strdup'd at each consumption site. Re-enable once IR owns its strings.
+    // ir_free_program(ir);
+    (void)ir;
+    free_ast_node(ast);
+    free_parser(parser);
+    free_lexer(lexer);
     free(source);
 
     return EXIT_SUCCESS;
 }
 
-char* readFile(const char* filename) {
+static char* readFile(const char* filename) {
     FILE* file = fopen(filename, "r");
     if (!file) {
         perror("Error opening file");
         return NULL;
     }
 
-    // Get file size
     fseek(file, 0, SEEK_END);
     long size = ftell(file);
     fseek(file, 0, SEEK_SET);
@@ -63,16 +115,4 @@ char* readFile(const char* filename) {
     fclose(file);
 
     return buffer;
-}
-
-void processCypLang(const char* source) {
-    printf("CypLang source code:\n%s\n", source);
-    printf("--------------------------------\n");
-    printf("(Replace this with actual CypLang processing)\n");
-
-    printf("\nOutput:\n");
-
-    if (strstr(source, "4 + 4") != NULL) {
-        printf("x = 8\n");
-    }
 }

--- a/src/middle/ir_generator.c
+++ b/src/middle/ir_generator.c
@@ -222,27 +222,39 @@ char* generate_ir_from_assignment(IRProgram* program, AstAssignment* assign) {
     }
 }
 
-void generate_ir_from_if_statement(IRProgram* program, AstNode* node) {
-    char* condition = generate_ir_from_node(program, node, NULL);
+void generate_ir_from_if_statement(IRProgram* program, AstIfStatement* if_stmt) {
+    char* condition = generate_ir_from_node(program, if_stmt->condition, NULL);
 
     char* else_label = new_label(program);
     char* end_label = new_label(program);
 
+    // if !cond goto else_label
     IrInstruction* if_inst = create_instruction(IR_IF_GOTO);
     if_inst->arg1 = condition;
-    if_inst->label = else_label;
+    if_inst->label = strdup(else_label);
     emit_instruction(program, if_inst);
 
-    IrInstruction* else_label_inst = create_instruction(IR_LABEL);
-    else_label_inst->label = strdup(else_label);
-    emit_instruction(program, else_label_inst);
+    // then branch
+    generate_ir_from_node(program, if_stmt->then_branch, NULL);
 
+    // goto end
     IrInstruction* goto_end = create_instruction(IR_GOTO);
-    goto_end->label = end_label;
+    goto_end->label = strdup(end_label);
     emit_instruction(program, goto_end);
 
+    // else_label:
+    IrInstruction* else_label_inst = create_instruction(IR_LABEL);
+    else_label_inst->label = else_label;
+    emit_instruction(program, else_label_inst);
+
+    // else branch (optional)
+    if (if_stmt->else_branch) {
+        generate_ir_from_node(program, if_stmt->else_branch, NULL);
+    }
+
+    // end_label:
     IrInstruction* end_label_inst = create_instruction(IR_LABEL);
-    end_label_inst->label = strdup(end_label);
+    end_label_inst->label = end_label;
     emit_instruction(program, end_label_inst);
 }
 
@@ -435,7 +447,7 @@ char* generate_ir_from_node(IRProgram* program, AstNode* node, char* result_var)
         case AST_UNARY_EXPR:
             return generate_ir_from_unary_expr(program, (AstUnaryExpr*)node);
         case AST_IF_STATEMENT:
-            generate_ir_from_if_statement(program, node);
+            generate_ir_from_if_statement(program, (AstIfStatement*)node);
             return NULL;
         case AST_WHILE_STATEMENT:
             generate_ir_from_while_statement(program, (AstWhileStatement*)node);


### PR DESCRIPTION
## Summary
Phase 1 de la reprise du projet : on câble le pipeline de compilation
complet dans `main.c` et on corrige plusieurs bugs latents qui empêchaient
le compilateur de produire un IR exploitable.

Avant ce PR, `main.c` contenait du code placeholder (`strstr("4 + 4")`)
qui n'appelait jamais le lexer, le parser ni le générateur d'IR.

## Changements

### Câblage du pipeline
- **`src/main.c`** : réécriture complète. Appelle désormais
  `init_lexer` → `init_parser` → `parse` → `print_ast` → `generate_ir` →
  `ir_print_program`, avec gestion d'erreur à chaque étape.

### AST — structs manquantes / incohérentes
- **`ast.h`** : ajout de la struct `AstIfStatement` (condition / then_branch /
  else_branch). Auparavant, `AST_IF_STATEMENT` existait dans l'enum mais
  était stocké via un cast bricolé vers `AstBlock`.
- **`ast.h`** : ajout des champs `arguments` / `argument_count` dans
  `AstFunctionCall`. Le constructeur recevait les arguments mais ne les
  stockait pas (commentaire `// Note: We're not storing the arguments`).
- **`ast.c`** : `create_if_stmt_node`, `create_function_call_node`,
  `print_ast`, `free_ast_node` mis à jour pour les nouvelles structs.

### Bugs latents corrigés
- **`parser.c` `parse_block`** : le TODO interne signalait que les
  statements parsés n'étaient jamais ajoutés au bloc. Le pipeline produisait
  donc des blocs vides. Corrigé avec un tableau dynamique.
- **`ir_generator.c` `generate_ir_from_if_statement`** : récursion infinie
  (la fonction se rappelait sur son propre nœud d'entrée). Refait avec la
  nouvelle struct `AstIfStatement`, génère correctement les branches
  then/else et les labels.

### Build
- **`Makefile`** : `wildcard $(SRC_DIR)/*.c` ne trouvait que `main.c` car
  les sources sont dans des sous-dossiers. Remplacé par un `find` récursif,
  avec `mkdir -p $(dir $@)` pour créer les sous-dossiers d'objets.
- **`CMakeLists.txt`** : version minimale alignée sur le README (3.31 → 3.10).

## Test plan
- [x] `make clean && make` compile sans erreur
- [x] `./build/bin/cyplang test.cyp` sur `entier x <- 4 + 4` produit l'IR
      three-address attendu (`t0=4`, `t1=4`, `t2=t0+t1`, `x=t2`)
- [x] Exit code 0
- [ ] Tester avec un fichier contenant un `si ... alors ... sinon ... finsi`
- [ ] Tester avec un fichier contenant une fonction `DEBFONC ... FINFONC`

## Dette technique connue (à traiter en Phase 1.5)
`ir_free_program` est temporairement désactivé dans `main.c` (TODO documenté) :
les chaînes de temps (`t0`, `t1`...) sont partagées par pointeur entre
plusieurs `IrInstruction` au lieu d'être `strdup`ées à chaque consommation,
ce qui cause un double-free. À corriger avant d'attaquer le backend LLVM.
