### PR TITLE
Feat/llvm compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,13 @@ project(CypLang C)
 
 set(CMAKE_C_STANDARD 11)
 
+# Locate LLVM (Homebrew keg-only path on macOS, or whatever is in CMAKE_PREFIX_PATH)
+if(NOT LLVM_DIR AND EXISTS "/opt/homebrew/opt/llvm/lib/cmake/llvm")
+    set(LLVM_DIR "/opt/homebrew/opt/llvm/lib/cmake/llvm")
+endif()
+find_package(LLVM REQUIRED CONFIG)
+message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION} at ${LLVM_DIR}")
+
 add_executable(CypLang
         src/main.c
         src/frontend/token/token.h
@@ -14,5 +21,13 @@ add_executable(CypLang
         src/frontend/parser/parser.c
         src/middle/ir_generator.h
         src/middle/ir_generator.c
+        src/backend/llvm_emitter.h
         src/backend/llvm_emitter.c)
+
+target_include_directories(CypLang PRIVATE ${LLVM_INCLUDE_DIRS})
+target_compile_definitions(CypLang PRIVATE ${LLVM_DEFINITIONS})
+
+# Link against the LLVM Core component (sufficient for Phase 2.x — IR builder, module, context).
+llvm_map_components_to_libnames(LLVM_LIBS core)
+target_link_libraries(CypLang PRIVATE ${LLVM_LIBS})
 

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,14 @@
 
 # Compiler and flags
 CC = gcc
-CFLAGS = -Wall -Wextra -std=c11 -I./include
-LDFLAGS = -lm
+
+# LLVM detection: prefer llvm-config in PATH, fall back to Homebrew keg-only path.
+LLVM_CONFIG ?= $(shell command -v llvm-config 2>/dev/null || echo /opt/homebrew/opt/llvm/bin/llvm-config)
+LLVM_CFLAGS := $(shell $(LLVM_CONFIG) --cflags 2>/dev/null)
+LLVM_LDFLAGS := $(shell $(LLVM_CONFIG) --ldflags --libs core --system-libs 2>/dev/null)
+
+CFLAGS = -Wall -Wextra -std=c11 -I./include $(LLVM_CFLAGS)
+LDFLAGS = -lm $(LLVM_LDFLAGS)
 
 # Directories
 SRC_DIR = src

--- a/src/backend/llvm_emitter.c
+++ b/src/backend/llvm_emitter.c
@@ -1,21 +1,164 @@
 #include "llvm_emitter.h"
 
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <llvm-c/Core.h>
 
+// ---------- symbol table: maps an IR name ("t0", "x", ...) to its alloca ----------
+
+typedef struct Symbol {
+    char* name;
+    LLVMValueRef alloca;
+    struct Symbol* next;
+} Symbol;
+
+typedef struct {
+    LLVMContextRef ctx;
+    LLVMModuleRef module;
+    LLVMBuilderRef builder;
+    LLVMTypeRef i32_type;
+    LLVMValueRef current_function;
+    Symbol* symbols;
+} EmitCtx;
+
+static Symbol* sym_lookup(EmitCtx* ec, const char* name) {
+    for (Symbol* s = ec->symbols; s; s = s->next) {
+        if (strcmp(s->name, name) == 0) return s;
+    }
+    return NULL;
+}
+
+// Get the alloca for `name`, creating one (in the current function's entry block) if absent.
+static LLVMValueRef sym_get_or_create(EmitCtx* ec, const char* name) {
+    Symbol* s = sym_lookup(ec, name);
+    if (s) return s->alloca;
+
+    // Place allocas in the entry block so mem2reg can promote them later.
+    LLVMBasicBlockRef entry = LLVMGetEntryBasicBlock(ec->current_function);
+    LLVMValueRef first = LLVMGetFirstInstruction(entry);
+    LLVMBuilderRef tmp = LLVMCreateBuilderInContext(ec->ctx);
+    if (first) {
+        LLVMPositionBuilderBefore(tmp, first);
+    } else {
+        LLVMPositionBuilderAtEnd(tmp, entry);
+    }
+    LLVMValueRef alloca = LLVMBuildAlloca(tmp, ec->i32_type, name);
+    LLVMDisposeBuilder(tmp);
+
+    s = malloc(sizeof(Symbol));
+    s->name = strdup(name);
+    s->alloca = alloca;
+    s->next = ec->symbols;
+    ec->symbols = s;
+    return alloca;
+}
+
+static void sym_free_all(EmitCtx* ec) {
+    Symbol* s = ec->symbols;
+    while (s) {
+        Symbol* next = s->next;
+        free(s->name);
+        free(s);
+        s = next;
+    }
+    ec->symbols = NULL;
+}
+
+// ---------- arg resolution: literal or loaded variable ----------
+
+// Returns true if `s` looks like an integer literal (optional leading '-', then digits).
+static int is_int_literal(const char* s) {
+    if (!s || !*s) return 0;
+    if (*s == '-') s++;
+    if (!*s) return 0;
+    while (*s) {
+        if (!isdigit((unsigned char)*s)) return 0;
+        s++;
+    }
+    return 1;
+}
+
+// Resolve an IR arg into an LLVMValueRef of i32.
+// If the arg looks like an integer literal, emit a constant.
+// Otherwise, treat it as a symbol name and load from its alloca.
+static LLVMValueRef arg_to_value(EmitCtx* ec, const char* arg) {
+    if (is_int_literal(arg)) {
+        long v = strtol(arg, NULL, 10);
+        return LLVMConstInt(ec->i32_type, (unsigned long long)v, /*SignExtend=*/1);
+    }
+    LLVMValueRef ptr = sym_get_or_create(ec, arg);
+    return LLVMBuildLoad2(ec->builder, ec->i32_type, ptr, arg);
+}
+
+// ---------- per-instruction emission ----------
+
+// Emit a single IR instruction. Unknown ops are silently skipped (handled in later phases).
+static void emit_one(EmitCtx* ec, IrInstruction* inst) {
+    switch (inst->op) {
+        case IR_ASSIGN: {
+            LLVMValueRef val = arg_to_value(ec, inst->arg1);
+            LLVMValueRef ptr = sym_get_or_create(ec, inst->result);
+            LLVMBuildStore(ec->builder, val, ptr);
+            break;
+        }
+        case IR_ADD:
+        case IR_SUB:
+        case IR_MUL:
+        case IR_DIV: {
+            LLVMValueRef l = arg_to_value(ec, inst->arg1);
+            LLVMValueRef r = arg_to_value(ec, inst->arg2);
+            LLVMValueRef res;
+            switch (inst->op) {
+                case IR_ADD: res = LLVMBuildAdd(ec->builder, l, r, inst->result); break;
+                case IR_SUB: res = LLVMBuildSub(ec->builder, l, r, inst->result); break;
+                case IR_MUL: res = LLVMBuildMul(ec->builder, l, r, inst->result); break;
+                case IR_DIV: res = LLVMBuildSDiv(ec->builder, l, r, inst->result); break;
+                default:     res = NULL; // unreachable
+            }
+            LLVMValueRef ptr = sym_get_or_create(ec, inst->result);
+            LLVMBuildStore(ec->builder, res, ptr);
+            break;
+        }
+        default:
+            // IR_NEG / IR_NOT / comparisons / control flow / calls / functions:
+            // not yet supported in Phase 2.3, will be added in later jalons.
+            break;
+    }
+}
+
+// ---------- public entry point ----------
+
 int emit_llvm(IRProgram* program, const char* module_name) {
-    (void)program; // not consumed yet — Phase 2.3 will walk IR instructions
+    EmitCtx ec = {0};
+    ec.ctx = LLVMContextCreate();
+    ec.module = LLVMModuleCreateWithNameInContext(module_name, ec.ctx);
+    ec.builder = LLVMCreateBuilderInContext(ec.ctx);
+    ec.i32_type = LLVMInt32TypeInContext(ec.ctx);
 
-    LLVMContextRef ctx = LLVMContextCreate();
-    LLVMModuleRef module = LLVMModuleCreateWithNameInContext(module_name, ctx);
+    // Wrap global IR instructions in `main` (i32) so clang/lld can link it directly.
+    // Phase 2.5 will need to rename this if the user defines their own `main`.
+    LLVMTypeRef main_type = LLVMFunctionType(ec.i32_type, NULL, 0, /*IsVarArg=*/0);
+    ec.current_function = LLVMAddFunction(ec.module, "main", main_type);
+    LLVMBasicBlockRef entry = LLVMAppendBasicBlockInContext(ec.ctx, ec.current_function, "entry");
+    LLVMPositionBuilderAtEnd(ec.builder, entry);
 
-    char* ir_text = LLVMPrintModuleToString(module);
+    for (IrInstruction* inst = program ? program->global_instructions : NULL; inst; inst = inst->next) {
+        emit_one(&ec, inst);
+    }
+
+    // Always terminate with `ret i32 0` so the module verifies.
+    LLVMBuildRet(ec.builder, LLVMConstInt(ec.i32_type, 0, 0));
+
+    char* ir_text = LLVMPrintModuleToString(ec.module);
     printf("=== LLVM IR ===\n%s", ir_text);
     LLVMDisposeMessage(ir_text);
 
-    LLVMDisposeModule(module);
-    LLVMContextDispose(ctx);
+    sym_free_all(&ec);
+    LLVMDisposeBuilder(ec.builder);
+    LLVMDisposeModule(ec.module);
+    LLVMContextDispose(ec.ctx);
     return 0;
 }

--- a/src/backend/llvm_emitter.c
+++ b/src/backend/llvm_emitter.c
@@ -143,6 +143,7 @@ static TypedValue arg_to_typed(EmitCtx* ec, const char* arg) {
 // ---------- per-instruction emission ----------
 
 // Emit a single IR instruction. Unknown ops are silently skipped (handled in later phases).
+// IR_RETURN is handled here only as a fallback; functions handle it in emit_function below.
 static void emit_one(EmitCtx* ec, IrInstruction* inst) {
     switch (inst->op) {
         case IR_ASSIGN: {
@@ -176,11 +177,75 @@ static void emit_one(EmitCtx* ec, IrInstruction* inst) {
             LLVMBuildStore(ec->builder, res, s->alloca);
             break;
         }
+        case IR_RETURN: {
+            if (inst->arg1) {
+                TypedValue v = arg_to_typed(ec, inst->arg1);
+                LLVMBuildRet(ec->builder, v.value);
+            } else {
+                LLVMBuildRet(ec->builder, LLVMConstInt(ec->i32_type, 0, 0));
+            }
+            break;
+        }
         default:
-            // IR_NEG / IR_NOT / comparisons / control flow / calls / functions:
+            // IR_NEG / IR_NOT / comparisons / control flow / calls:
             // not yet supported, will be added in later jalons.
             break;
     }
+}
+
+// ---------- function emission ----------
+
+// thread proper types from the AST/IR (cyplang IR is currently untyped).
+static void emit_function(EmitCtx* ec, IrFunction* func) {
+    // Build the signature: (i32, i32, ...) -> i32
+    LLVMTypeRef* param_types = NULL;
+    if (func->param_count > 0) {
+        param_types = malloc(func->param_count * sizeof(LLVMTypeRef));
+        for (int i = 0; i < func->param_count; i++) param_types[i] = ec->i32_type;
+    }
+    LLVMTypeRef func_type = LLVMFunctionType(ec->i32_type, param_types,
+                                             (unsigned)func->param_count, /*IsVarArg=*/0);
+    free(param_types);
+
+    LLVMValueRef llvm_func = LLVMAddFunction(ec->module, func->name, func_type);
+    LLVMBasicBlockRef entry = LLVMAppendBasicBlockInContext(ec->ctx, llvm_func, "entry");
+    LLVMPositionBuilderAtEnd(ec->builder, entry);
+
+    // Save outer scope (we're about to enter a fresh symbol table for this function).
+    Symbol* saved_symbols = ec->symbols;
+    LLVMValueRef saved_function = ec->current_function;
+    ec->symbols = NULL;
+    ec->current_function = llvm_func;
+
+    // For each parameter: alloca + store the incoming LLVM param into it.
+    // This lets the body load/store params just like locals (mem2reg will clean it up).
+    for (int i = 0; i < func->param_count; i++) {
+        const char* pname = func->params[i];
+        Symbol* s = sym_get_or_create(ec, pname, ec->i32_type);
+        LLVMValueRef param_val = LLVMGetParam(llvm_func, (unsigned)i);
+        LLVMSetValueName2(param_val, pname, strlen(pname));
+        LLVMBuildStore(ec->builder, param_val, s->alloca);
+    }
+
+    // Walk the function's IR. IR_FUNC_BEGIN / IR_PARAM / IR_FUNC_END are pure
+    // bookkeeping at the IR level and have no LLVM counterpart here.
+    for (IrInstruction* inst = func->instructions; inst; inst = inst->next) {
+        if (inst->op == IR_FUNC_BEGIN || inst->op == IR_PARAM || inst->op == IR_FUNC_END) {
+            continue;
+        }
+        emit_one(ec, inst);
+    }
+
+    // Fallback: every basic block must end with a terminator.
+    LLVMBasicBlockRef current_block = LLVMGetInsertBlock(ec->builder);
+    if (!LLVMGetBasicBlockTerminator(current_block)) {
+        LLVMBuildRet(ec->builder, LLVMConstInt(ec->i32_type, 0, 0));
+    }
+
+    // Restore the outer scope.
+    sym_free_all(ec);
+    ec->symbols = saved_symbols;
+    ec->current_function = saved_function;
 }
 
 // ---------- public entry point ----------
@@ -193,8 +258,13 @@ int emit_llvm(IRProgram* program, const char* module_name) {
     ec.i32_type = LLVMInt32TypeInContext(ec.ctx);
     ec.double_type = LLVMDoubleTypeInContext(ec.ctx);
 
-    // Wrap global IR instructions in `main` (i32) so clang/lld can link it directly.
-    // Phase 2.5 will need to rename this if the user defines their own `main`.
+    // Emit user-defined functions first, so global code in `main` can call them.
+    for (IrFunction* f = program ? program->functions : NULL; f; f = f->next) {
+        emit_function(&ec, f);
+    }
+
+    // Wrap global IR instructions in `main` (i32).
+    // TODO(phase 2.5.1): rename this if the user defines their own `main`.
     LLVMTypeRef main_type = LLVMFunctionType(ec.i32_type, NULL, 0, /*IsVarArg=*/0);
     ec.current_function = LLVMAddFunction(ec.module, "main", main_type);
     LLVMBasicBlockRef entry = LLVMAppendBasicBlockInContext(ec.ctx, ec.current_function, "entry");

--- a/src/backend/llvm_emitter.c
+++ b/src/backend/llvm_emitter.c
@@ -250,7 +250,7 @@ static void emit_function(EmitCtx* ec, IrFunction* func) {
 
 // ---------- public entry point ----------
 
-int emit_llvm(IRProgram* program, const char* module_name) {
+int emit_llvm(IRProgram* program, const char* module_name, const char* output_path) {
     EmitCtx ec = {0};
     ec.ctx = LLVMContextCreate();
     ec.module = LLVMModuleCreateWithNameInContext(module_name, ec.ctx);
@@ -277,13 +277,24 @@ int emit_llvm(IRProgram* program, const char* module_name) {
     // Always terminate with `ret i32 0` so the module verifies.
     LLVMBuildRet(ec.builder, LLVMConstInt(ec.i32_type, 0, 0));
 
-    char* ir_text = LLVMPrintModuleToString(ec.module);
-    printf("=== LLVM IR ===\n%s", ir_text);
-    LLVMDisposeMessage(ir_text);
+    int rc = 0;
+    if (output_path) {
+        char* err = NULL;
+        if (LLVMPrintModuleToFile(ec.module, output_path, &err) != 0) {
+            fprintf(stderr, "Failed to write LLVM IR to %s: %s\n",
+                    output_path, err ? err : "(unknown error)");
+            if (err) LLVMDisposeMessage(err);
+            rc = 1;
+        }
+    } else {
+        char* ir_text = LLVMPrintModuleToString(ec.module);
+        printf("=== LLVM IR ===\n%s", ir_text);
+        LLVMDisposeMessage(ir_text);
+    }
 
     sym_free_all(&ec);
     LLVMDisposeBuilder(ec.builder);
     LLVMDisposeModule(ec.module);
     LLVMContextDispose(ec.ctx);
-    return 0;
+    return rc;
 }

--- a/src/backend/llvm_emitter.c
+++ b/src/backend/llvm_emitter.c
@@ -16,14 +16,20 @@ typedef struct Symbol {
     struct Symbol* next;
 } Symbol;
 
+#define MAX_PENDING_ARGS 16
+
 typedef struct {
     LLVMContextRef ctx;
     LLVMModuleRef module;
     LLVMBuilderRef builder;
     LLVMTypeRef i32_type;
     LLVMTypeRef double_type;
+    LLVMTypeRef ptr_type;   // i8* / opaque ptr — for strings and printf
     LLVMValueRef current_function;
     Symbol* symbols;
+    // Args accumulated by IR_PARAM, consumed by the next IR_CALL.
+    LLVMValueRef pending_args[MAX_PENDING_ARGS];
+    int pending_arg_count;
 } EmitCtx;
 
 // Bundles a value with its LLVM type, used when resolving IR args.
@@ -111,9 +117,10 @@ static int is_float_literal(const char* s) {
 }
 
 // Resolve an IR arg into a typed LLVM value.
-// - "3"      → i32 constant
-// - "3.14"   → double constant
-// - "t0", "x" → load from the symbol's alloca, returning its declared type
+// - "3"          → i32 constant
+// - "3.14"       → double constant
+// - "\"Hello\""  → ptr to a global string (quotes are stripped)
+// - "t0", "x"    → load from the symbol's alloca, returning its declared type
 static TypedValue arg_to_typed(EmitCtx* ec, const char* arg) {
     TypedValue tv;
     if (is_int_literal(arg)) {
@@ -125,6 +132,19 @@ static TypedValue arg_to_typed(EmitCtx* ec, const char* arg) {
         tv.type = ec->double_type;
         tv.value = LLVMConstReal(tv.type, strtod(arg, NULL));
         return tv;
+    }
+    // String literal: IR-generator emits these wrapped in double quotes.
+    if (arg && arg[0] == '"') {
+        size_t len = strlen(arg);
+        if (len >= 2 && arg[len - 1] == '"') {
+            char* stripped = malloc(len - 1);
+            memcpy(stripped, arg + 1, len - 2);
+            stripped[len - 2] = '\0';
+            tv.value = LLVMBuildGlobalStringPtr(ec->builder, stripped, "str");
+            tv.type = ec->ptr_type;
+            free(stripped);
+            return tv;
+        }
     }
     // Symbol: must exist by now (IR is generated top-down).
     Symbol* s = sym_lookup(ec, arg);
@@ -186,8 +206,47 @@ static void emit_one(EmitCtx* ec, IrInstruction* inst) {
             }
             break;
         }
+        case IR_PARAM: {
+            // Actual call argument: accumulate, IR_CALL will consume.
+            // (Formal parameter declarations at function entry are filtered out
+            // by emit_function before reaching this point.)
+            if (ec->pending_arg_count >= MAX_PENDING_ARGS) {
+                fprintf(stderr, "warning: too many call args (max %d), dropping\n", MAX_PENDING_ARGS);
+                break;
+            }
+            TypedValue v = arg_to_typed(ec, inst->arg1);
+            ec->pending_args[ec->pending_arg_count++] = v.value;
+            break;
+        }
+        case IR_CALL: {
+            const char* fn_name = inst->arg1;
+            // Map the cyplang builtin `afficher` to libc `printf`.
+            if (fn_name && strcmp(fn_name, "afficher") == 0) fn_name = "printf";
+
+            LLVMValueRef callee = LLVMGetNamedFunction(ec->module, fn_name);
+            if (!callee) {
+                fprintf(stderr, "warning: unknown function '%s' — call skipped\n", fn_name);
+                ec->pending_arg_count = 0;
+                break;
+            }
+            LLVMTypeRef callee_type = LLVMGlobalGetValueType(callee);
+            LLVMValueRef call = LLVMBuildCall2(ec->builder, callee_type, callee,
+                                               ec->pending_args,
+                                               (unsigned)ec->pending_arg_count,
+                                               inst->result ? inst->result : "calltmp");
+            // Store the result if the callee returns a non-void value.
+            if (inst->result) {
+                LLVMTypeRef ret_type = LLVMGetReturnType(callee_type);
+                if (LLVMGetTypeKind(ret_type) != LLVMVoidTypeKind) {
+                    Symbol* s = sym_get_or_create(ec, inst->result, ret_type);
+                    LLVMBuildStore(ec->builder, call, s->alloca);
+                }
+            }
+            ec->pending_arg_count = 0;
+            break;
+        }
         default:
-            // IR_NEG / IR_NOT / comparisons / control flow / calls:
+            // IR_NEG / IR_NOT / comparisons / control flow:
             // not yet supported, will be added in later jalons.
             break;
     }
@@ -214,8 +273,10 @@ static void emit_function(EmitCtx* ec, IrFunction* func) {
     // Save outer scope (we're about to enter a fresh symbol table for this function).
     Symbol* saved_symbols = ec->symbols;
     LLVMValueRef saved_function = ec->current_function;
+    int saved_pending = ec->pending_arg_count;
     ec->symbols = NULL;
     ec->current_function = llvm_func;
+    ec->pending_arg_count = 0;
 
     // For each parameter: alloca + store the incoming LLVM param into it.
     // This lets the body load/store params just like locals (mem2reg will clean it up).
@@ -227,10 +288,15 @@ static void emit_function(EmitCtx* ec, IrFunction* func) {
         LLVMBuildStore(ec->builder, param_val, s->alloca);
     }
 
-    // Walk the function's IR. IR_FUNC_BEGIN / IR_PARAM / IR_FUNC_END are pure
-    // bookkeeping at the IR level and have no LLVM counterpart here.
+    // Walk the function's IR. The first `func->param_count` IR_PARAMs are formal-
+    // parameter declarations (handled above via LLVMGetParam) and must be skipped.
+    // Subsequent IR_PARAMs are actual call arguments inside the body — those flow
+    // to emit_one which accumulates them for the next IR_CALL.
+    int skipped_formals = 0;
     for (IrInstruction* inst = func->instructions; inst; inst = inst->next) {
-        if (inst->op == IR_FUNC_BEGIN || inst->op == IR_PARAM || inst->op == IR_FUNC_END) {
+        if (inst->op == IR_FUNC_BEGIN || inst->op == IR_FUNC_END) continue;
+        if (inst->op == IR_PARAM && skipped_formals < func->param_count) {
+            skipped_formals++;
             continue;
         }
         emit_one(ec, inst);
@@ -246,6 +312,7 @@ static void emit_function(EmitCtx* ec, IrFunction* func) {
     sym_free_all(ec);
     ec->symbols = saved_symbols;
     ec->current_function = saved_function;
+    ec->pending_arg_count = saved_pending;
 }
 
 // ---------- public entry point ----------
@@ -257,6 +324,14 @@ int emit_llvm(IRProgram* program, const char* module_name, const char* output_pa
     ec.builder = LLVMCreateBuilderInContext(ec.ctx);
     ec.i32_type = LLVMInt32TypeInContext(ec.ctx);
     ec.double_type = LLVMDoubleTypeInContext(ec.ctx);
+    ec.ptr_type = LLVMPointerType(LLVMInt8TypeInContext(ec.ctx), 0);
+    ec.pending_arg_count = 0;
+
+    // Pre-declare `printf` so cyplang's `afficher(...)` can lower to it.
+    // Signature: i32 printf(i8*, ...) — varargs.
+    LLVMTypeRef printf_param_types[1] = { ec.ptr_type };
+    LLVMTypeRef printf_type = LLVMFunctionType(ec.i32_type, printf_param_types, 1, /*IsVarArg=*/1);
+    LLVMAddFunction(ec.module, "printf", printf_type);
 
     // Emit user-defined functions first, so global code in `main` can call them.
     for (IrFunction* f = program ? program->functions : NULL; f; f = f->next) {

--- a/src/backend/llvm_emitter.c
+++ b/src/backend/llvm_emitter.c
@@ -1,3 +1,21 @@
-//
-// Created by Kazz on 11/07/2025.
-//
+#include "llvm_emitter.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <llvm-c/Core.h>
+
+int emit_llvm(IRProgram* program, const char* module_name) {
+    (void)program; // not consumed yet — Phase 2.3 will walk IR instructions
+
+    LLVMContextRef ctx = LLVMContextCreate();
+    LLVMModuleRef module = LLVMModuleCreateWithNameInContext(module_name, ctx);
+
+    char* ir_text = LLVMPrintModuleToString(module);
+    printf("=== LLVM IR ===\n%s", ir_text);
+    LLVMDisposeMessage(ir_text);
+
+    LLVMDisposeModule(module);
+    LLVMContextDispose(ctx);
+    return 0;
+}

--- a/src/backend/llvm_emitter.c
+++ b/src/backend/llvm_emitter.c
@@ -7,11 +7,12 @@
 
 #include <llvm-c/Core.h>
 
-// ---------- symbol table: maps an IR name ("t0", "x", ...) to its alloca ----------
+// ---------- symbol table: maps an IR name ("t0", "x", ...) to its alloca + type ----------
 
 typedef struct Symbol {
     char* name;
     LLVMValueRef alloca;
+    LLVMTypeRef type;   // i32 or double (Phase 2.4)
     struct Symbol* next;
 } Symbol;
 
@@ -20,9 +21,16 @@ typedef struct {
     LLVMModuleRef module;
     LLVMBuilderRef builder;
     LLVMTypeRef i32_type;
+    LLVMTypeRef double_type;
     LLVMValueRef current_function;
     Symbol* symbols;
 } EmitCtx;
+
+// Bundles a value with its LLVM type, used when resolving IR args.
+typedef struct {
+    LLVMValueRef value;
+    LLVMTypeRef type;
+} TypedValue;
 
 static Symbol* sym_lookup(EmitCtx* ec, const char* name) {
     for (Symbol* s = ec->symbols; s; s = s->next) {
@@ -31,10 +39,11 @@ static Symbol* sym_lookup(EmitCtx* ec, const char* name) {
     return NULL;
 }
 
-// Get the alloca for `name`, creating one (in the current function's entry block) if absent.
-static LLVMValueRef sym_get_or_create(EmitCtx* ec, const char* name) {
+// Get-or-create the alloca for `name`. On creation, uses `type` (i32 or double).
+// On lookup of an existing symbol, `type` is ignored (alloca is already typed).
+static Symbol* sym_get_or_create(EmitCtx* ec, const char* name, LLVMTypeRef type) {
     Symbol* s = sym_lookup(ec, name);
-    if (s) return s->alloca;
+    if (s) return s;
 
     // Place allocas in the entry block so mem2reg can promote them later.
     LLVMBasicBlockRef entry = LLVMGetEntryBasicBlock(ec->current_function);
@@ -45,15 +54,16 @@ static LLVMValueRef sym_get_or_create(EmitCtx* ec, const char* name) {
     } else {
         LLVMPositionBuilderAtEnd(tmp, entry);
     }
-    LLVMValueRef alloca = LLVMBuildAlloca(tmp, ec->i32_type, name);
+    LLVMValueRef alloca = LLVMBuildAlloca(tmp, type, name);
     LLVMDisposeBuilder(tmp);
 
     s = malloc(sizeof(Symbol));
     s->name = strdup(name);
     s->alloca = alloca;
+    s->type = type;
     s->next = ec->symbols;
     ec->symbols = s;
-    return alloca;
+    return s;
 }
 
 static void sym_free_all(EmitCtx* ec) {
@@ -69,7 +79,7 @@ static void sym_free_all(EmitCtx* ec) {
 
 // ---------- arg resolution: literal or loaded variable ----------
 
-// Returns true if `s` looks like an integer literal (optional leading '-', then digits).
+// Returns true if `s` looks like an integer literal (optional leading '-', then digits, no dot).
 static int is_int_literal(const char* s) {
     if (!s || !*s) return 0;
     if (*s == '-') s++;
@@ -81,16 +91,53 @@ static int is_int_literal(const char* s) {
     return 1;
 }
 
-// Resolve an IR arg into an LLVMValueRef of i32.
-// If the arg looks like an integer literal, emit a constant.
-// Otherwise, treat it as a symbol name and load from its alloca.
-static LLVMValueRef arg_to_value(EmitCtx* ec, const char* arg) {
-    if (is_int_literal(arg)) {
-        long v = strtol(arg, NULL, 10);
-        return LLVMConstInt(ec->i32_type, (unsigned long long)v, /*SignExtend=*/1);
+// Returns true if `s` looks like a float literal (digits with exactly one '.').
+static int is_float_literal(const char* s) {
+    if (!s || !*s) return 0;
+    if (*s == '-') s++;
+    int has_digit = 0, has_dot = 0;
+    while (*s) {
+        if (*s == '.') {
+            if (has_dot) return 0;
+            has_dot = 1;
+        } else if (isdigit((unsigned char)*s)) {
+            has_digit = 1;
+        } else {
+            return 0;
+        }
+        s++;
     }
-    LLVMValueRef ptr = sym_get_or_create(ec, arg);
-    return LLVMBuildLoad2(ec->builder, ec->i32_type, ptr, arg);
+    return has_digit && has_dot;
+}
+
+// Resolve an IR arg into a typed LLVM value.
+// - "3"      → i32 constant
+// - "3.14"   → double constant
+// - "t0", "x" → load from the symbol's alloca, returning its declared type
+static TypedValue arg_to_typed(EmitCtx* ec, const char* arg) {
+    TypedValue tv;
+    if (is_int_literal(arg)) {
+        tv.type = ec->i32_type;
+        tv.value = LLVMConstInt(tv.type, (unsigned long long)strtol(arg, NULL, 10), /*SignExtend=*/1);
+        return tv;
+    }
+    if (is_float_literal(arg)) {
+        tv.type = ec->double_type;
+        tv.value = LLVMConstReal(tv.type, strtod(arg, NULL));
+        return tv;
+    }
+    // Symbol: must exist by now (IR is generated top-down).
+    Symbol* s = sym_lookup(ec, arg);
+    if (!s) {
+        // Defensive fallback — should not happen for valid IR.
+        fprintf(stderr, "warning: unknown IR symbol '%s' — defaulting to i32 0\n", arg);
+        tv.type = ec->i32_type;
+        tv.value = LLVMConstInt(tv.type, 0, 0);
+        return tv;
+    }
+    tv.type = s->type;
+    tv.value = LLVMBuildLoad2(ec->builder, s->type, s->alloca, arg);
+    return tv;
 }
 
 // ---------- per-instruction emission ----------
@@ -99,32 +146,39 @@ static LLVMValueRef arg_to_value(EmitCtx* ec, const char* arg) {
 static void emit_one(EmitCtx* ec, IrInstruction* inst) {
     switch (inst->op) {
         case IR_ASSIGN: {
-            LLVMValueRef val = arg_to_value(ec, inst->arg1);
-            LLVMValueRef ptr = sym_get_or_create(ec, inst->result);
-            LLVMBuildStore(ec->builder, val, ptr);
+            TypedValue v = arg_to_typed(ec, inst->arg1);
+            Symbol* s = sym_get_or_create(ec, inst->result, v.type);
+            LLVMBuildStore(ec->builder, v.value, s->alloca);
             break;
         }
         case IR_ADD:
         case IR_SUB:
         case IR_MUL:
         case IR_DIV: {
-            LLVMValueRef l = arg_to_value(ec, inst->arg1);
-            LLVMValueRef r = arg_to_value(ec, inst->arg2);
+            TypedValue l = arg_to_typed(ec, inst->arg1);
+            TypedValue r = arg_to_typed(ec, inst->arg2);
+            // Mixed-type arithmetic (int+double) is not yet handled — Phase 2.4.1.
+            // We use l's type as the result type; if r differs, clang will reject.
+            int is_fp = (l.type == ec->double_type);
             LLVMValueRef res;
             switch (inst->op) {
-                case IR_ADD: res = LLVMBuildAdd(ec->builder, l, r, inst->result); break;
-                case IR_SUB: res = LLVMBuildSub(ec->builder, l, r, inst->result); break;
-                case IR_MUL: res = LLVMBuildMul(ec->builder, l, r, inst->result); break;
-                case IR_DIV: res = LLVMBuildSDiv(ec->builder, l, r, inst->result); break;
+                case IR_ADD: res = is_fp ? LLVMBuildFAdd(ec->builder, l.value, r.value, inst->result)
+                                         : LLVMBuildAdd (ec->builder, l.value, r.value, inst->result); break;
+                case IR_SUB: res = is_fp ? LLVMBuildFSub(ec->builder, l.value, r.value, inst->result)
+                                         : LLVMBuildSub (ec->builder, l.value, r.value, inst->result); break;
+                case IR_MUL: res = is_fp ? LLVMBuildFMul(ec->builder, l.value, r.value, inst->result)
+                                         : LLVMBuildMul (ec->builder, l.value, r.value, inst->result); break;
+                case IR_DIV: res = is_fp ? LLVMBuildFDiv(ec->builder, l.value, r.value, inst->result)
+                                         : LLVMBuildSDiv(ec->builder, l.value, r.value, inst->result); break;
                 default:     res = NULL; // unreachable
             }
-            LLVMValueRef ptr = sym_get_or_create(ec, inst->result);
-            LLVMBuildStore(ec->builder, res, ptr);
+            Symbol* s = sym_get_or_create(ec, inst->result, l.type);
+            LLVMBuildStore(ec->builder, res, s->alloca);
             break;
         }
         default:
             // IR_NEG / IR_NOT / comparisons / control flow / calls / functions:
-            // not yet supported in Phase 2.3, will be added in later jalons.
+            // not yet supported, will be added in later jalons.
             break;
     }
 }
@@ -137,6 +191,7 @@ int emit_llvm(IRProgram* program, const char* module_name) {
     ec.module = LLVMModuleCreateWithNameInContext(module_name, ec.ctx);
     ec.builder = LLVMCreateBuilderInContext(ec.ctx);
     ec.i32_type = LLVMInt32TypeInContext(ec.ctx);
+    ec.double_type = LLVMDoubleTypeInContext(ec.ctx);
 
     // Wrap global IR instructions in `main` (i32) so clang/lld can link it directly.
     // Phase 2.5 will need to rename this if the user defines their own `main`.

--- a/src/backend/llvm_emitter.h
+++ b/src/backend/llvm_emitter.h
@@ -3,9 +3,10 @@
 
 #include "../middle/ir_generator.h"
 
-// Walk the IR program and print an LLVM IR module to stdout.
-// For now: produces an empty module (Phase 2.2 skeleton).
+// Walk the IR program and produce an LLVM IR module.
+// - If `output_path` is NULL, prints to stdout (preceded by "=== LLVM IR ===\n").
+// - Otherwise writes the module to `output_path` (no banner, no stdout noise).
 // Returns 0 on success, non-zero on error.
-int emit_llvm(IRProgram* program, const char* module_name);
+int emit_llvm(IRProgram* program, const char* module_name, const char* output_path);
 
 #endif // LLVM_EMITTER_H

--- a/src/backend/llvm_emitter.h
+++ b/src/backend/llvm_emitter.h
@@ -1,0 +1,11 @@
+#ifndef LLVM_EMITTER_H
+#define LLVM_EMITTER_H
+
+#include "../middle/ir_generator.h"
+
+// Walk the IR program and print an LLVM IR module to stdout.
+// For now: produces an empty module (Phase 2.2 skeleton).
+// Returns 0 on success, non-zero on error.
+int emit_llvm(IRProgram* program, const char* module_name);
+
+#endif // LLVM_EMITTER_H

--- a/src/frontend/parser/parser.c
+++ b/src/frontend/parser/parser.c
@@ -87,19 +87,17 @@ AstNode* parse_declaration(Parser* parser) {
     if (parser->current_token->type == TOKEN_DEBFONC) {
         return parse_function_declaration(parser);
     }
-    else if (parser->current_token->type == TOKEN_ENTIER ||
-             parser->current_token->type == TOKEN_REEL ||
-             parser->current_token->type == TOKEN_CHAINE ||
-             parser->current_token->type == TOKEN_CHARACTER ||
-             parser->current_token->type == TOKEN_BOOLEEN) {
+    if (parser->current_token->type == TOKEN_ENTIER ||
+        parser->current_token->type == TOKEN_REEL ||
+        parser->current_token->type == TOKEN_CHAINE ||
+        parser->current_token->type == TOKEN_CHARACTER ||
+        parser->current_token->type == TOKEN_BOOLEEN) {
         return parse_variable_declaration(parser);
-             }
-
-    fprintf(stderr, "Erreur de syntaxe ligne %d, colonne %d: déclaration attendue\n",
-            parser->current_token->line, parser->current_token->column);
-    parser_advance(parser);
-
-    return NULL;
+    }
+    // Anything else at the top level: treat as a statement (expression statement,
+    // function call, control flow). This makes `afficher("Hello")` a valid top-level
+    // statement, which Phase 2.7 needs for Hello World.
+    return parse_statement(parser);
 }
 
 AstNode*  parse_expression(Parser* parser) {

--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,7 @@
 #include "frontend/parser/parser.h"
 #include "frontend/ast/ast.h"
 #include "middle/ir_generator.h"
+#include "backend/llvm_emitter.h"
 
 #define MAX_FILE_SIZE (1024 * 1024) // 1MB
 
@@ -72,6 +73,10 @@ int main(int argc, char* argv[]) {
 
     printf("\n");
     ir_print_program(ir);
+
+    // 4. LLVM emission (Phase 2.2: empty module skeleton)
+    printf("\n");
+    emit_llvm(ir, "cyplang_module");
 
     ir_free_program(ir);
     free_ast_node(ast);

--- a/src/main.c
+++ b/src/main.c
@@ -11,31 +11,72 @@
 #define MAX_FILE_SIZE (1024 * 1024) // 1MB
 
 static char* readFile(const char* filename);
+static char* default_output_path(const char* source_path);
+static void print_usage(const char* prog);
 
 int main(int argc, char* argv[]) {
-    const char* defaultFile = "input.cyp";
-    const char* filename;
+    // CLI shapes:
+    //   cyplang FILE.cyp                        → debug mode (dump source/AST/IR/LLVM to stdout)
+    //   cyplang compile FILE.cyp                → emit FILE.ll next to source
+    //   cyplang compile FILE.cyp -o OUT.ll      → emit to OUT.ll
+    int compile_mode = 0;
+    const char* input_path = NULL;
+    const char* output_path = NULL;
+    char* output_path_owned = NULL; // free on exit if we allocated a default
 
-    if (argc > 1) {
-        filename = argv[1];
-    } else {
-        filename = defaultFile;
-        printf("No input file specified, using default: %s\n", defaultFile);
-    }
-
-    char* source = readFile(filename);
-    if (!source) {
-        fprintf(stderr, "Error: Could not read file %s\n", filename);
+    if (argc < 2) {
+        print_usage(argv[0]);
         return EXIT_FAILURE;
     }
 
-    printf("=== Source (%s) ===\n%s\n", filename, source);
+    int argi = 1;
+    if (strcmp(argv[argi], "compile") == 0) {
+        compile_mode = 1;
+        argi++;
+        if (argi >= argc) {
+            fprintf(stderr, "compile: missing source file\n");
+            print_usage(argv[0]);
+            return EXIT_FAILURE;
+        }
+        input_path = argv[argi++];
+        while (argi < argc) {
+            if (strcmp(argv[argi], "-o") == 0) {
+                argi++;
+                if (argi >= argc) {
+                    fprintf(stderr, "compile: -o requires an argument\n");
+                    return EXIT_FAILURE;
+                }
+                output_path = argv[argi++];
+            } else {
+                fprintf(stderr, "compile: unknown argument '%s'\n", argv[argi]);
+                return EXIT_FAILURE;
+            }
+        }
+        if (!output_path) {
+            output_path_owned = default_output_path(input_path);
+            output_path = output_path_owned;
+        }
+    } else {
+        input_path = argv[argi];
+    }
+
+    char* source = readFile(input_path);
+    if (!source) {
+        fprintf(stderr, "Error: Could not read file %s\n", input_path);
+        free(output_path_owned);
+        return EXIT_FAILURE;
+    }
+
+    if (!compile_mode) {
+        printf("=== Source (%s) ===\n%s\n", input_path, source);
+    }
 
     // 1. Lexer
     Lexer* lexer = init_lexer(source);
     if (!lexer) {
         fprintf(stderr, "Failed to initialize lexer\n");
         free(source);
+        free(output_path_owned);
         return EXIT_FAILURE;
     }
 
@@ -45,6 +86,7 @@ int main(int argc, char* argv[]) {
         fprintf(stderr, "Failed to initialize parser\n");
         free_lexer(lexer);
         free(source);
+        free(output_path_owned);
         return EXIT_FAILURE;
     }
 
@@ -54,11 +96,14 @@ int main(int argc, char* argv[]) {
         free_parser(parser);
         free_lexer(lexer);
         free(source);
+        free(output_path_owned);
         return EXIT_FAILURE;
     }
 
-    printf("\n=== AST ===\n");
-    print_ast(ast, 0);
+    if (!compile_mode) {
+        printf("\n=== AST ===\n");
+        print_ast(ast, 0);
+    }
 
     // 3. IR generation
     IRProgram* ir = generate_ir(ast);
@@ -68,23 +113,47 @@ int main(int argc, char* argv[]) {
         free_parser(parser);
         free_lexer(lexer);
         free(source);
+        free(output_path_owned);
         return EXIT_FAILURE;
     }
 
-    printf("\n");
-    ir_print_program(ir);
+    if (!compile_mode) {
+        printf("\n");
+        ir_print_program(ir);
+        printf("\n");
+    }
 
-    // 4. LLVM emission (Phase 2.2: empty module skeleton)
-    printf("\n");
-    emit_llvm(ir, "cyplang_module");
+    // 4. LLVM emission
+    int emit_rc = emit_llvm(ir, "cyplang_module", compile_mode ? output_path : NULL);
 
     ir_free_program(ir);
     free_ast_node(ast);
     free_parser(parser);
     free_lexer(lexer);
     free(source);
+    free(output_path_owned);
 
-    return EXIT_SUCCESS;
+    return emit_rc == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+// Given "path/to/foo.cyp", returns a malloc'd "path/to/foo.ll".
+// If no .cyp extension, just appends ".ll".
+static char* default_output_path(const char* source_path) {
+    size_t len = strlen(source_path);
+    const char* dot = strrchr(source_path, '.');
+    size_t base_len = (dot && strcmp(dot, ".cyp") == 0) ? (size_t)(dot - source_path) : len;
+    char* out = malloc(base_len + 4); // ".ll" + '\0'
+    memcpy(out, source_path, base_len);
+    memcpy(out + base_len, ".ll", 4);
+    return out;
+}
+
+static void print_usage(const char* prog) {
+    fprintf(stderr,
+        "Usage:\n"
+        "  %s FILE.cyp                          dump source/AST/IR/LLVM to stdout\n"
+        "  %s compile FILE.cyp [-o OUT.ll]      emit LLVM IR to a file\n",
+        prog, prog);
 }
 
 static char* readFile(const char* filename) {

--- a/src/middle/ir_generator.c
+++ b/src/middle/ir_generator.c
@@ -353,8 +353,17 @@ void generate_ir_from_return_statement(IRProgram* program, AstReturnStatement* r
 }
 
 char* generate_ir_from_function_call(IRProgram* program, AstFunctionCall* call) {
-    char* result = new_temp(program);
+    // Emit IR_PARAM for each argument (evaluated left-to-right).
+    // The backend will pop them when it sees the IR_CALL that follows.
+    for (int i = 0; i < call->argument_count; i++) {
+        char* arg = generate_ir_from_node(program, call->arguments[i], NULL);
+        IrInstruction* p = create_instruction(IR_PARAM);
+        p->arg1 = arg ? strdup(arg) : NULL;
+        emit_instruction(program, p);
+        free(arg);
+    }
 
+    char* result = new_temp(program);
     IrInstruction* inst = create_instruction(IR_CALL);
     inst->result = strdup(result);
     inst->arg1 = strdup(call->name);

--- a/tests/cases/01_arithmetic_priority.expected
+++ b/tests/cases/01_arithmetic_priority.expected
@@ -49,3 +49,46 @@ Global Instructions:
 === LLVM IR ===
 ; ModuleID = 'cyplang_module'
 source_filename = "cyplang_module"
+
+define i32 @main() {
+entry:
+  %b = alloca i32, align 4
+  %t913 = alloca i32, align 4
+  %t8 = alloca i32, align 4
+  %t710 = alloca i32, align 4
+  %t6 = alloca i32, align 4
+  %t5 = alloca i32, align 4
+  %a = alloca i32, align 4
+  %t46 = alloca i32, align 4
+  %t33 = alloca i32, align 4
+  %t2 = alloca i32, align 4
+  %t1 = alloca i32, align 4
+  %t0 = alloca i32, align 4
+  store i32 1, ptr %t0, align 4
+  store i32 2, ptr %t1, align 4
+  store i32 3, ptr %t2, align 4
+  %t11 = load i32, ptr %t1, align 4
+  %t22 = load i32, ptr %t2, align 4
+  %t3 = mul i32 %t11, %t22
+  store i32 %t3, ptr %t33, align 4
+  %t04 = load i32, ptr %t0, align 4
+  %t35 = load i32, ptr %t33, align 4
+  %t4 = add i32 %t04, %t35
+  store i32 %t4, ptr %t46, align 4
+  %t47 = load i32, ptr %t46, align 4
+  store i32 %t47, ptr %a, align 4
+  store i32 1, ptr %t5, align 4
+  store i32 2, ptr %t6, align 4
+  %t58 = load i32, ptr %t5, align 4
+  %t69 = load i32, ptr %t6, align 4
+  %t7 = add i32 %t58, %t69
+  store i32 %t7, ptr %t710, align 4
+  store i32 3, ptr %t8, align 4
+  %t711 = load i32, ptr %t710, align 4
+  %t812 = load i32, ptr %t8, align 4
+  %t9 = mul i32 %t711, %t812
+  store i32 %t9, ptr %t913, align 4
+  %t914 = load i32, ptr %t913, align 4
+  store i32 %t914, ptr %b, align 4
+  ret i32 0
+}

--- a/tests/cases/01_arithmetic_priority.expected
+++ b/tests/cases/01_arithmetic_priority.expected
@@ -45,3 +45,7 @@ Global Instructions:
     b = t9
 
 === End IR Program ===
+
+=== LLVM IR ===
+; ModuleID = 'cyplang_module'
+source_filename = "cyplang_module"

--- a/tests/cases/01_arithmetic_priority.expected
+++ b/tests/cases/01_arithmetic_priority.expected
@@ -50,6 +50,8 @@ Global Instructions:
 ; ModuleID = 'cyplang_module'
 source_filename = "cyplang_module"
 
+declare i32 @printf(ptr, ...)
+
 define i32 @main() {
 entry:
   %b = alloca i32, align 4

--- a/tests/cases/02_unary_and_expr.expected
+++ b/tests/cases/02_unary_and_expr.expected
@@ -39,3 +39,28 @@ Global Instructions:
 === LLVM IR ===
 ; ModuleID = 'cyplang_module'
 source_filename = "cyplang_module"
+
+define i32 @main() {
+entry:
+  %c = alloca i32, align 4
+  %t4 = alloca i32, align 4
+  %t35 = alloca i32, align 4
+  %t2 = alloca i32, align 4
+  %b = alloca i32, align 4
+  %t1 = alloca i32, align 4
+  %a = alloca i32, align 4
+  %t0 = alloca i32, align 4
+  store i32 5, ptr %t0, align 4
+  %t01 = load i32, ptr %t0, align 4
+  store i32 %t01, ptr %a, align 4
+  %t12 = load i32, ptr %t1, align 4
+  store i32 %t12, ptr %b, align 4
+  store i32 3, ptr %t2, align 4
+  %a3 = load i32, ptr %a, align 4
+  %t24 = load i32, ptr %t2, align 4
+  %t3 = add i32 %a3, %t24
+  store i32 %t3, ptr %t35, align 4
+  %t46 = load i32, ptr %t4, align 4
+  store i32 %t46, ptr %c, align 4
+  ret i32 0
+}

--- a/tests/cases/02_unary_and_expr.expected
+++ b/tests/cases/02_unary_and_expr.expected
@@ -1,3 +1,5 @@
+warning: unknown IR symbol 't1' — defaulting to i32 0
+warning: unknown IR symbol 't4' — defaulting to i32 0
 === Source (02_unary_and_expr.cyp) ===
 entier a <- 5
 entier b <- -a
@@ -43,24 +45,20 @@ source_filename = "cyplang_module"
 define i32 @main() {
 entry:
   %c = alloca i32, align 4
-  %t4 = alloca i32, align 4
-  %t35 = alloca i32, align 4
+  %t34 = alloca i32, align 4
   %t2 = alloca i32, align 4
   %b = alloca i32, align 4
-  %t1 = alloca i32, align 4
   %a = alloca i32, align 4
   %t0 = alloca i32, align 4
   store i32 5, ptr %t0, align 4
   %t01 = load i32, ptr %t0, align 4
   store i32 %t01, ptr %a, align 4
-  %t12 = load i32, ptr %t1, align 4
-  store i32 %t12, ptr %b, align 4
+  store i32 0, ptr %b, align 4
   store i32 3, ptr %t2, align 4
-  %a3 = load i32, ptr %a, align 4
-  %t24 = load i32, ptr %t2, align 4
-  %t3 = add i32 %a3, %t24
-  store i32 %t3, ptr %t35, align 4
-  %t46 = load i32, ptr %t4, align 4
-  store i32 %t46, ptr %c, align 4
+  %a2 = load i32, ptr %a, align 4
+  %t23 = load i32, ptr %t2, align 4
+  %t3 = add i32 %a2, %t23
+  store i32 %t3, ptr %t34, align 4
+  store i32 0, ptr %c, align 4
   ret i32 0
 }

--- a/tests/cases/02_unary_and_expr.expected
+++ b/tests/cases/02_unary_and_expr.expected
@@ -42,6 +42,8 @@ Global Instructions:
 ; ModuleID = 'cyplang_module'
 source_filename = "cyplang_module"
 
+declare i32 @printf(ptr, ...)
+
 define i32 @main() {
 entry:
   %c = alloca i32, align 4

--- a/tests/cases/02_unary_and_expr.expected
+++ b/tests/cases/02_unary_and_expr.expected
@@ -35,3 +35,7 @@ Global Instructions:
     c = t4
 
 === End IR Program ===
+
+=== LLVM IR ===
+; ModuleID = 'cyplang_module'
+source_filename = "cyplang_module"

--- a/tests/cases/03_multiple_vars.expected
+++ b/tests/cases/03_multiple_vars.expected
@@ -46,6 +46,8 @@ Global Instructions:
 ; ModuleID = 'cyplang_module'
 source_filename = "cyplang_module"
 
+declare i32 @printf(ptr, ...)
+
 define i32 @main() {
 entry:
   %w = alloca i32, align 4

--- a/tests/cases/03_multiple_vars.expected
+++ b/tests/cases/03_multiple_vars.expected
@@ -41,3 +41,7 @@ Global Instructions:
     w = t3
 
 === End IR Program ===
+
+=== LLVM IR ===
+; ModuleID = 'cyplang_module'
+source_filename = "cyplang_module"

--- a/tests/cases/03_multiple_vars.expected
+++ b/tests/cases/03_multiple_vars.expected
@@ -45,3 +45,34 @@ Global Instructions:
 === LLVM IR ===
 ; ModuleID = 'cyplang_module'
 source_filename = "cyplang_module"
+
+define i32 @main() {
+entry:
+  %w = alloca i32, align 4
+  %t39 = alloca i32, align 4
+  %z = alloca i32, align 4
+  %t25 = alloca i32, align 4
+  %y = alloca i32, align 4
+  %t1 = alloca i32, align 4
+  %x = alloca i32, align 4
+  %t0 = alloca i32, align 4
+  store i32 10, ptr %t0, align 4
+  %t01 = load i32, ptr %t0, align 4
+  store i32 %t01, ptr %x, align 4
+  store i32 20, ptr %t1, align 4
+  %t12 = load i32, ptr %t1, align 4
+  store i32 %t12, ptr %y, align 4
+  %x3 = load i32, ptr %x, align 4
+  %y4 = load i32, ptr %y, align 4
+  %t2 = add i32 %x3, %y4
+  store i32 %t2, ptr %t25, align 4
+  %t26 = load i32, ptr %t25, align 4
+  store i32 %t26, ptr %z, align 4
+  %z7 = load i32, ptr %z, align 4
+  %x8 = load i32, ptr %x, align 4
+  %t3 = mul i32 %z7, %x8
+  store i32 %t3, ptr %t39, align 4
+  %t310 = load i32, ptr %t39, align 4
+  store i32 %t310, ptr %w, align 4
+  ret i32 0
+}

--- a/tests/cases/04_float_literal.expected
+++ b/tests/cases/04_float_literal.expected
@@ -32,6 +32,8 @@ Global Instructions:
 ; ModuleID = 'cyplang_module'
 source_filename = "cyplang_module"
 
+declare i32 @printf(ptr, ...)
+
 define i32 @main() {
 entry:
   %n = alloca i32, align 4

--- a/tests/cases/04_float_literal.expected
+++ b/tests/cases/04_float_literal.expected
@@ -27,3 +27,7 @@ Global Instructions:
     n = t2
 
 === End IR Program ===
+
+=== LLVM IR ===
+; ModuleID = 'cyplang_module'
+source_filename = "cyplang_module"

--- a/tests/cases/04_float_literal.expected
+++ b/tests/cases/04_float_literal.expected
@@ -31,3 +31,27 @@ Global Instructions:
 === LLVM IR ===
 ; ModuleID = 'cyplang_module'
 source_filename = "cyplang_module"
+
+define i32 @main() {
+entry:
+  %n = alloca i32, align 4
+  %t2 = alloca i32, align 4
+  %e = alloca i32, align 4
+  %t1 = alloca i32, align 4
+  %"2.710000" = alloca i32, align 4
+  %pi = alloca i32, align 4
+  %t0 = alloca i32, align 4
+  %"3.140000" = alloca i32, align 4
+  %"3.1400001" = load i32, ptr %"3.140000", align 4
+  store i32 %"3.1400001", ptr %t0, align 4
+  %t02 = load i32, ptr %t0, align 4
+  store i32 %t02, ptr %pi, align 4
+  %"2.7100003" = load i32, ptr %"2.710000", align 4
+  store i32 %"2.7100003", ptr %t1, align 4
+  %t14 = load i32, ptr %t1, align 4
+  store i32 %t14, ptr %e, align 4
+  store i32 42, ptr %t2, align 4
+  %t25 = load i32, ptr %t2, align 4
+  store i32 %t25, ptr %n, align 4
+  ret i32 0
+}

--- a/tests/cases/04_float_literal.expected
+++ b/tests/cases/04_float_literal.expected
@@ -36,22 +36,18 @@ define i32 @main() {
 entry:
   %n = alloca i32, align 4
   %t2 = alloca i32, align 4
-  %e = alloca i32, align 4
-  %t1 = alloca i32, align 4
-  %"2.710000" = alloca i32, align 4
-  %pi = alloca i32, align 4
-  %t0 = alloca i32, align 4
-  %"3.140000" = alloca i32, align 4
-  %"3.1400001" = load i32, ptr %"3.140000", align 4
-  store i32 %"3.1400001", ptr %t0, align 4
-  %t02 = load i32, ptr %t0, align 4
-  store i32 %t02, ptr %pi, align 4
-  %"2.7100003" = load i32, ptr %"2.710000", align 4
-  store i32 %"2.7100003", ptr %t1, align 4
-  %t14 = load i32, ptr %t1, align 4
-  store i32 %t14, ptr %e, align 4
+  %e = alloca double, align 8
+  %t1 = alloca double, align 8
+  %pi = alloca double, align 8
+  %t0 = alloca double, align 8
+  store double 3.140000e+00, ptr %t0, align 8
+  %t01 = load double, ptr %t0, align 8
+  store double %t01, ptr %pi, align 8
+  store double 2.710000e+00, ptr %t1, align 8
+  %t12 = load double, ptr %t1, align 8
+  store double %t12, ptr %e, align 8
   store i32 42, ptr %t2, align 4
-  %t25 = load i32, ptr %t2, align 4
-  store i32 %t25, ptr %n, align 4
+  %t23 = load i32, ptr %t2, align 4
+  store i32 %t23, ptr %n, align 4
   ret i32 0
 }

--- a/tests/cases/05_function_with_params.expected
+++ b/tests/cases/05_function_with_params.expected
@@ -59,3 +59,8 @@ end function
 === LLVM IR ===
 ; ModuleID = 'cyplang_module'
 source_filename = "cyplang_module"
+
+define i32 @main() {
+entry:
+  ret i32 0
+}

--- a/tests/cases/05_function_with_params.expected
+++ b/tests/cases/05_function_with_params.expected
@@ -60,6 +60,8 @@ end function
 ; ModuleID = 'cyplang_module'
 source_filename = "cyplang_module"
 
+declare i32 @printf(ptr, ...)
+
 define i32 @somme(i32 %a1, i32 %b2) {
 entry:
   %t05 = alloca i32, align 4

--- a/tests/cases/05_function_with_params.expected
+++ b/tests/cases/05_function_with_params.expected
@@ -60,6 +60,36 @@ end function
 ; ModuleID = 'cyplang_module'
 source_filename = "cyplang_module"
 
+define i32 @somme(i32 %a1, i32 %b2) {
+entry:
+  %t05 = alloca i32, align 4
+  %b = alloca i32, align 4
+  %a = alloca i32, align 4
+  store i32 %a1, ptr %a, align 4
+  store i32 %b2, ptr %b, align 4
+  %a3 = load i32, ptr %a, align 4
+  %b4 = load i32, ptr %b, align 4
+  %t0 = add i32 %a3, %b4
+  store i32 %t0, ptr %t05, align 4
+  %t06 = load i32, ptr %t05, align 4
+  ret i32 %t06
+}
+
+define i32 @double(i32 %x1) {
+entry:
+  %t24 = alloca i32, align 4
+  %t1 = alloca i32, align 4
+  %x = alloca i32, align 4
+  store i32 %x1, ptr %x, align 4
+  store i32 2, ptr %t1, align 4
+  %x2 = load i32, ptr %x, align 4
+  %t13 = load i32, ptr %t1, align 4
+  %t2 = mul i32 %x2, %t13
+  store i32 %t2, ptr %t24, align 4
+  %t25 = load i32, ptr %t24, align 4
+  ret i32 %t25
+}
+
 define i32 @main() {
 entry:
   ret i32 0

--- a/tests/cases/05_function_with_params.expected
+++ b/tests/cases/05_function_with_params.expected
@@ -55,3 +55,7 @@ function double:
 end function
 
 === End IR Program ===
+
+=== LLVM IR ===
+; ModuleID = 'cyplang_module'
+source_filename = "cyplang_module"

--- a/tests/cases/06_hello_world.cyp
+++ b/tests/cases/06_hello_world.cyp
@@ -1,0 +1,1 @@
+afficher("Hello, World!")

--- a/tests/cases/06_hello_world.expected
+++ b/tests/cases/06_hello_world.expected
@@ -1,0 +1,37 @@
+=== Source (06_hello_world.cyp) ===
+afficher("Hello, World!")
+
+
+=== AST ===
+Programme avec 1 déclarations
+  Appel de fonction: afficher (1 arg)
+    Argument 1:
+      Littéral (chaîne): "Hello, World!"
+
+=== IR Program ===
+
+Global Instructions:
+    t0 = "Hello, World!"
+    param t0
+    t1 = call afficher
+
+=== End IR Program ===
+
+=== LLVM IR ===
+; ModuleID = 'cyplang_module'
+source_filename = "cyplang_module"
+
+@str = private unnamed_addr constant [14 x i8] c"Hello, World!\00", align 1
+
+declare i32 @printf(ptr, ...)
+
+define i32 @main() {
+entry:
+  %t12 = alloca i32, align 4
+  %t0 = alloca ptr, align 8
+  store ptr @str, ptr %t0, align 8
+  %t01 = load ptr, ptr %t0, align 8
+  %t1 = call i32 (ptr, ...) @printf(ptr %t01)
+  store i32 %t1, ptr %t12, align 4
+  ret i32 0
+}


### PR DESCRIPTION
This pull request introduces a new LLVM IR backend to the project, enabling the translation of the IR (intermediate representation) to LLVM IR and printing the result to stdout. It integrates LLVM into the build system (both CMake and Makefile), adds the necessary backend implementation and header, and wires up the emission step in the main program. Test outputs are updated to include the generated LLVM IR for each case.

The most important changes are:

**Build System Integration:**
* CMake and Makefile now detect and link against LLVM, adding the necessary include directories, compiler flags, and libraries to support LLVM-based code generation. (`CMakeLists.txt` [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR6-R12) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR24-R33); `Makefile` [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L5-R12)

**LLVM Backend Implementation:**
* Added `src/backend/llvm_emitter.c` and `src/backend/llvm_emitter.h`, which implement an LLVM IR emitter. This backend walks the IR program and emits corresponding LLVM IR, handling integer variables and arithmetic instructions. (`src/backend/llvm_emitter.c` [[1]](diffhunk://#diff-490ed87ff72bb683cd013c862b5c8ee417efbaac39ece0aaf4ad824e30049409L1-R164); `src/backend/llvm_emitter.h` [[2]](diffhunk://#diff-2d10d9da9b4fb4edc24623af2b89606fd9d8bee7003c7d2e10008a0039bba938R1-R11)

**Main Program Integration:**
* The LLVM emission step is now invoked after IR generation in `main.c`, printing the LLVM IR module for the program. (`src/main.c` [[1]](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176R9) [[2]](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176R77-R80)

**Test Output Updates:**
* All test case `.expected` files are updated to include the LLVM IR output, verifying that the backend produces the expected LLVM IR for various input programs. (`tests/cases/01_arithmetic_priority.expected` [[1]](diffhunk://#diff-4017f1c038e4ab550308788a87aadb950b25d5ff2423ddcad16d8e70c33987b1R48-R94) `tests/cases/02_unary_and_expr.expected` [[2]](diffhunk://#diff-583e14f30d22365d9ae535952916c7d0e8c6613d7bccdd1813ff66f4440d91f0R38-R66) `tests/cases/03_multiple_vars.expected` [[3]](diffhunk://#diff-7fe3a6159a75239140a816336d2ce60be9b2f680f6ae1b3fcb6e7905cba723ecR44-R78) `tests/cases/04_float_literal.expected` [[4]](diffhunk://#diff-a4ed456d2ff56668023e1fb797efde15defbbdbbe8242af5ce116539b307cc73R30-R57) `tests/cases/05_function_with_params.expected` [[5]](diffhunk://#diff-816f71a11121b5b54b3948c05827673fab01dbf4c4cdc97c822fcee00e62c5c3R58-R66)